### PR TITLE
Slackクライアントを最新のdebで入れる

### DIFF
--- a/linux/ansible/roles/slowest_pkgs/tasks/main.yml
+++ b/linux/ansible/roles/slowest_pkgs/tasks/main.yml
@@ -10,9 +10,18 @@
       | tail -n1
   register: vagrant_version
 
+- name: get latest slack desktop app download url
+  shell: |
+    wget https://slack.com/downloads/instructions/ubuntu -O - \
+      | sed -e 's/"/\n/g' \
+      | grep /slack-desktop \
+      | grep ".deb"
+  register: slack_deb_url
+
 - name: install from specific download site
   apt: deb={{ item }} state=present
   with_items:
     - "https://release.gitkraken.com/linux/gitkraken-amd64.deb"
     - "https://www.rescuetime.com/installers/rescuetime_current_amd64.deb"
     - "https://releases.hashicorp.com/vagrant/{{ vagrant_version.stdout }}/vagrant_{{ vagrant_version.stdout }}_{{ ansible_architecture }}.deb"
+    - "{{ slack_deb_url.stdout }}"


### PR DESCRIPTION
https://slack.com/intl/ja-jp/downloads/linux を参考にした。

* snap版なら、このような面倒なくインストールできたが、ibus-skkを受けつけなかったため模索した。
* FirefoxなどブラウザでSlackは何も問題がなかった。
* deb版も、ibus-skkを受けつけたので、利用することにした。

なおSlack社がベータ版と謳っているとおり、ダウンロードリンクやURLなど変化する可能性がある。スクレイピングの宿命だな。