### PR TITLE
Zoomアプリをインストールする

### DIFF
--- a/linux/ansible/roles/slowest_pkgs/tasks/main.yml
+++ b/linux/ansible/roles/slowest_pkgs/tasks/main.yml
@@ -25,3 +25,4 @@
     - "https://www.rescuetime.com/installers/rescuetime_current_amd64.deb"
     - "https://releases.hashicorp.com/vagrant/{{ vagrant_version.stdout }}/vagrant_{{ vagrant_version.stdout }}_{{ ansible_architecture }}.deb"
     - "{{ slack_deb_url.stdout }}"
+    - "https://zoom.us/client/latest/zoom_amd64.deb"


### PR DESCRIPTION
Linux版ネイティブアプリがあるので入れる

* https://support.zoom.us/hc/en-us/articles/204206269-Installing-or-updating-Zoom-on-Linux#h_f75692f2-5e13-4526-ba87-216692521a82
* https://zoom.us/download?os=linux
    * Ubuntu, 64bit, 14.04+ で Download ボタンのリンク先になっているURLのdebを入れる