### PR TITLE
SQLクライアントアプリTablePlusをセットアップする

### DIFF
--- a/linux/ansible/roles/common/tasks/main.yml
+++ b/linux/ansible/roles/common/tasks/main.yml
@@ -22,6 +22,7 @@
     - "https://download.docker.com/linux/ubuntu/gpg"
     - "https://apt.enpass.io/keys/enpass-linux.key"
     - "https://packages.microsoft.com/keys/microsoft.asc"
+    - "http://deb.tableplus.com/apt.tableplus.com.gpg.key"
 
 - apt_repository: repo={{ item }} state=present
   with_items:
@@ -30,6 +31,7 @@
     - "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main"
     - "deb https://apt.enpass.io/ stable main"
     - "deb [arch=amd64] https://packages.microsoft.com/repos/vscode stable main"
+    - "deb [arch=amd64] https://deb.tableplus.com/debian tableplus main"
 
 - name: apt-get update
   apt: update_cache=yes
@@ -123,6 +125,7 @@
     - ssh
     - synaptic
     - sysstat
+    - tableplus
     - ubuntu-fan
     - unpaper
     - usb-creator-gtk


### PR DESCRIPTION
Macで使ってて大変気に入ってるTablePlus。Linux向けがアルファ版だけどリリースされてるので入れて使うぞ

https://tableplus.com/