### PR TITLE
親CLI magick のサブコマンドを呼ぶ形に改める

### DIFF
--- a/script/dir2pdf.sh
+++ b/script/dir2pdf.sh
@@ -11,7 +11,7 @@ find "$@" -type d | while read f; do
 	-o "$(pwd)"/"${OUTDIR}".pdf \
 	-s "A4" -t "" -a "" \
 	) \
-	|| convert -limit memory 2gb -limit map 2gb \
+	|| magick convert -limit memory 2gb -limit map 2gb \
 	"$(pwd)"/"${OUTDIR}"/*.{jpg,JPG,jpeg,JPEG,png,PNG} \
 	"$(pwd)"/"${OUTDIR}".pdf
 

--- a/script/hosei_chop.sh
+++ b/script/hosei_chop.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -v
 # 上下左右の削り取り
-mogrify -shave 50x50 "$@"
+magick mogrify -shave 50x50 "$@"

--- a/script/hosei_chop_bottom.sh
+++ b/script/hosei_chop_bottom.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -v
 # 下の削り取り
-mogrify -crop +0-50 "$@"
+magick mogrify -crop +0-50 "$@"

--- a/script/hosei_chop_left.sh
+++ b/script/hosei_chop_left.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -v
 # 左の削り取り
-mogrify -crop +50+0 "$@"
+magick mogrify -crop +50+0 "$@"

--- a/script/hosei_chop_right.sh
+++ b/script/hosei_chop_right.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -v
 # 右の削り取り
-mogrify -crop -50+0 "$@"
+magick mogrify -crop -50+0 "$@"

--- a/script/hosei_chop_side.sh
+++ b/script/hosei_chop_side.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -v
 # 左右の削り取り
-mogrify -shave 50x0 "$@"
+magick mogrify -shave 50x0 "$@"

--- a/script/hosei_chop_up.sh
+++ b/script/hosei_chop_up.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -v
 # 上の削り取り
-mogrify -crop +0+50 "$@"
+magick mogrify -crop +0+50 "$@"

--- a/script/hosei_chop_upside.sh
+++ b/script/hosei_chop_upside.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -v
 # 上下の削り取り
-mogrify -shave 0x50 "$@"
+magick mogrify -shave 0x50 "$@"

--- a/script/hosei_katamuki.sh
+++ b/script/hosei_katamuki.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -v
 # 自動傾き補正
-mogrify -deskew 40% "$@"
+magick mogrify -deskew 40% "$@"

--- a/script/hosei_level.sh
+++ b/script/hosei_level.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -v
 # 白黒クッキリ補正。liner-stretchによる補正では、ほぼ白/ほぼ黒が潰れてしまう問題があったため、別解として作成
-mogrify -level '25%,90%' "$@"
+magick mogrify -level '25%,90%' "$@"

--- a/script/hosei_quality.sh
+++ b/script/hosei_quality.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -v
 # 各補正をして肥大化した画像をスリムにする
-mogrify -quality 25 "$@"
+magick mogrify -quality 25 "$@"

--- a/script/hosei_sharpen.sh
+++ b/script/hosei_sharpen.sh
@@ -1,3 +1,3 @@
 #!/bin/sh -v
 # シャープにする
-mogrify -sharpen 4x4 "$@"
+magick mogrify -sharpen 4x4 "$@"

--- a/script/hosei_ura.sh
+++ b/script/hosei_ura.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -v
 # 裏写り補正。裏写りが消えるまで何度か実行する。
-mogrify -modulate 115 -contrast "$@"
+magick mogrify -modulate 115 -contrast "$@"

--- a/script/hosei_white.sh
+++ b/script/hosei_white.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -v
 # 白黒クッキリ補正。ほぼ白/ほぼ黒は、潰れて謎画像になる問題がある
 ls "$@" | while read f; do
-    convert -linear-stretch 5%x6% "$f" "$f.tmp"
+    magick convert -linear-stretch 5%x6% "$f" "$f.tmp"
     mv "$f.tmp" "$f"
 done

--- a/script/hosei_yake.sh
+++ b/script/hosei_yake.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -v
 # 紙焼け補正。
-mogrify -channel Red -separate "$@"
+magick mogrify -channel Red -separate "$@"


### PR DESCRIPTION
ImageMagick の CLI 体系がそのように改められたらしい
https://kage3.cocolog-nifty.com/blog/2023/06/post-4cec01.html

最近 Windows でこれらシェルスクリプトを動かそうとしたら、 Windows のシステムコマンド convert を動かしてしまうと気付いて状況調査したのであった。