### PR TITLE
chore: Remove legacy c9.sh shell script

### DIFF
--- a/c9/c9.sh
+++ b/c9/c9.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-docker run -it -d -p 9999:80 -v ~/git:/workspace/ -v ~/.ssh:/root/.ssh kdelfour/cloud9-docker
-


### PR DESCRIPTION
## Summary
- Remove `c9/c9.sh`, a legacy shell script that launched a Cloud9 Docker container

## Test plan
- [x] Verify no other scripts reference `c9.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)