### PR TITLE
script: Remove redundant context size argument

### DIFF
--- a/script/start-llama-server.sh
+++ b/script/start-llama-server.sh
@@ -28,7 +28,7 @@ ${LLAMA_SERVER} \
   --n-gpu-layers 99 \
   --cache-type-k q4_0 \
   --cache-type-v q4_0 \
-  -c ${CONTEXT_SIZE} --ctx-size ${CONTEXT_SIZE} \
+  --ctx-size ${CONTEXT_SIZE} \
   -fa on \
   --batch-size ${BATCH_SIZE} \
   --ubatch-size ${UBATCH_SIZE} \


### PR DESCRIPTION
## Summary
- Remove the redundant short \\-c context-size argument from start-llama-server.sh
- Keep the explicit --ctx-size setting as the single source of the context size

## Testing
- Not run; argument cleanup only