### PR TITLE
Tune llama-server checkpoint cache settings for OpenCode

### DIFF
--- a/script/start-llama-server.sh
+++ b/script/start-llama-server.sh
@@ -46,8 +46,11 @@ ${LLAMA_SERVER} \
   --top-p 0.95 \
   --top-k 20 \
   --min-p 0 \
-  --presence-penalty 0.5 \
+  --presence-penalty 0 \
   --repeat-penalty 1.0 \
+  --ctx-checkpoints 24 \
+  --cache-ram 32768 \
+  --checkpoint-min-step 256 \
   --chat-template-kwargs '{"preserve_thinking":true}' \
   --no-webui \
   --metrics \


### PR DESCRIPTION
## Summary

This PR tunes the local `llama-server` startup options for OpenCode agentic coding workloads.

The main change is to make llama.cpp context checkpoint behavior explicit after the recent server-side improvements around checkpoint creation before the latest user message. These settings are intended to reduce avoidable full prompt re-processing during long chat sessions.

## Changes

* Add explicit context checkpoint settings:

  * `--ctx-checkpoints 24`
  * `--cache-ram 32768`
  * `--checkpoint-min-step 256`
* Set `--presence-penalty 0` for coding-oriented usage

## Motivation

OpenCode repeatedly sends long, incrementally growing chat histories to the local OpenAI-compatible `llama-server`. Recent llama.cpp changes improved context checkpoint creation for such workloads, especially by creating checkpoints around useful chat-message boundaries.

These options make the intended checkpoint/cache behavior explicit and provide more RAM budget for checkpoint reuse, which should help avoid cases like:

```text
forcing full prompt re-processing due to lack of cache data
```

The presence penalty is also set to `0` because coding tasks often require repeating identifiers, file paths, function names, and similar code structures.

## Notes

This is not a throughput-oriented benchmark tuning change. The goal is not to improve raw token generation speed, but to improve practical responsiveness during long OpenCode sessions by reducing unnecessary prompt re-processing.

Further tuning should be based on actual `llama-server` logs rather than `llama-bench`, especially by watching for checkpoint creation/restoration and full prompt re-processing messages.
