### PR TITLE
config.bash: ハードコードされたパスを動的なパス解決に変更

### DIFF
--- a/.config/bash/config.bash
+++ b/.config/bash/config.bash
@@ -1,15 +1,18 @@
 # $HOME/.bashrc でこのファイルを . する
 
+# Resolve this directory relative to the location of this script
+BASH_CONFIG_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+
 # OS ごとの rc を読む
 case "$OSTYPE" in
   linux*)
-    [[ -f ~/.config/bash/os/linux.bash ]] && source ~/.config/bash/os/linux.bash
+    [[ -f "$BASH_CONFIG_DIR/os/linux.bash" ]] && source "$BASH_CONFIG_DIR/os/linux.bash"
     ;;
   darwin*)
-    [[ -f ~/.config/bash/os/darwin.bash ]] && source ~/.config/bash/os/darwin.bash
+    [[ -f "$BASH_CONFIG_DIR/os/darwin.bash" ]] && source "$BASH_CONFIG_DIR/os/darwin.bash"
     ;;
   msys*|cygwin*|win32*)
-    [[ -f ~/.config/bash/os/windows.bash ]] && source ~/.config/bash/os/windows.bash
+    [[ -f "$BASH_CONFIG_DIR/os/windows.bash" ]] && source "$BASH_CONFIG_DIR/os/windows.bash"
     ;;
   *)
     echo "Unknown: $OSTYPE"
@@ -17,17 +20,17 @@ case "$OSTYPE" in
 esac
 
 # Load config
-for f in ~/.config/bash/conf.d/*.bash; do
+for f in "$BASH_CONFIG_DIR/conf.d/"*.bash; do
     [ -f "$f" ] && eval "$(cat "$f")"
 done
 
 # Load functions
-for f in ~/.config/bash/functions/*.bash; do
+for f in "$BASH_CONFIG_DIR/functions/"*.bash; do
     [ -f "$f" ] && eval "$(cat "$f")"
 done
 
 # Load completions
-for f in ~/.config/bash/completions/*.bash; do
+for f in "$BASH_CONFIG_DIR/completions/"*.bash; do
     [ -f "$f" ] && eval "$(cat "$f")"
 done
 


### PR DESCRIPTION
## 概要

~/.config/bash 配下のパスをハードコードから動的なパス解決に変更しました。

## 変更内容

- `BASH_CONFIG_DIR` を `dirname "$(realpath "${BASH_SOURCE[0]}")"` で定義
- 全ての `~/.config/bash/...` を `/...` に置換

これにより、config.bash の設置場所が動的に解決され、ディレクトリ構成が変更しても正しく動作するようになります。