### PR TITLE
config: improve bash completion and atuin setup

### DIFF
--- a/.config/bash/completions/ghq.bash
+++ b/.config/bash/completions/ghq.bash
@@ -1,3 +1,4 @@
-# bash 起動する度に curl するのはどうかと思う
-# https://github.com/x-motemen/ghq/tree/master
-source <(curl -fsSL https://raw.githubusercontent.com/x-motemen/ghq/refs/heads/master/misc/bash/_ghq)
+if [[ ! -f ~/.bash-completion-ghq.sh ]]; then
+    curl -fsSL https://raw.githubusercontent.com/x-motemen/ghq/refs/heads/master/misc/bash/_ghq -o ~/.bash-completion-ghq.sh
+fi
+source ~/.bash-completion-ghq.sh

--- a/.config/bash/conf.d/atuin.bash
+++ b/.config/bash/conf.d/atuin.bash
@@ -1,5 +1,8 @@
 # https://docs.atuin.sh/cli/guide/installation/
-[[ -f ~/.bash-preexec.sh ]] && source ~/.bash-preexec.sh
+if [[ ! -f ~/.bash-preexec.sh ]]; then
+    curl https://raw.githubusercontent.com/rcaloras/bash-preexec/master/bash-preexec.sh -o ~/.bash-preexec.sh
+fi
+source ~/.bash-preexec.sh
 # https://hub.atuin.sh/
 # https://docs.atuin.sh/cli/
 if [[ $- == *i* ]] && [[ "${TERM:-}" != "dumb" ]] && command -v atuin >/dev/null 2>&1; then

--- a/.config/bash/conf.d/bash-completion.bash
+++ b/.config/bash/conf.d/bash-completion.bash
@@ -1,7 +1,0 @@
-# _init_completion などを completion が利用している。
-# Git for Windows の bash にバンドルされていない。
-# bash-completion は winget や scoop で配布されていない。
-# ghq get https://github.com/scop/bash-completion
-# したものを source することにした
-# macOS は homebrew で入手したものを利用する
-[[ -f ~/src/github.com/scop/bash-completion/bash_completion ]] && . ~/src/github.com/scop/bash-completion/bash_completion

--- a/.config/bash/conf.d/editor.bash
+++ b/.config/bash/conf.d/editor.bash
@@ -1,0 +1,5 @@
+# https://opencode.ai/docs/ja/tui/
+export EDITOR='code --wait'
+
+# micro は長い。 vi みたく mi で起動できてほしい
+alias mi='micro'

--- a/.config/bash/config.bash
+++ b/.config/bash/config.bash
@@ -33,6 +33,3 @@ done
 for f in "$BASH_CONFIG_DIR/completions/"*.bash; do
     [ -f "$f" ] && eval "$(cat "$f")"
 done
-
-# https://opencode.ai/docs/ja/tui/
-export EDITOR='code --wait'

--- a/.config/bash/os/darwin.bash
+++ b/.config/bash/os/darwin.bash
@@ -47,8 +47,6 @@ export AWS_VAULT_BACKEND=keychain
 export AWS_VAULT_PASS_PREFIX=aws-vault
 export AWS_SESSION_TOKEN_TTL=3h
 
-alias mi='micro'
-
 unset -f prepend_path
 
 # fzf --bash

--- a/.config/bash/os/windows.bash
+++ b/.config/bash/os/windows.bash
@@ -22,3 +22,11 @@ export OPENCODE_GIT_BASH_PATH=${CLAUDE_CODE_GIT_BASH_PATH}
 export MSYS=winsymlinks:nativestrict
 # なお Windows 11 では一般ユーザーでシンボリックリンクを作成するには追加の権限が必要で、
 # Windows 11 25h2 では [ 設定 > システム > 詳細設定 > 開発者モード ON ] で作成可能になる。
+
+# _init_completion などを completion が利用している。
+# Git for Windows の bash にバンドルされていない。
+# bash-completion は winget や scoop で配布されていない。
+# ghq get https://github.com/scop/bash-completion
+# したものを source することにした
+# macOS は homebrew で入手したものを利用する
+[[ -f ~/src/github.com/scop/bash-completion/bash_completion ]] && . ~/src/github.com/scop/bash-completion/bash_completion


### PR DESCRIPTION
## Changes

- [atuin.bash] Auto-download bash-preexec.sh if not exists
- [ghq.bash] Cache ghq completion script locally instead of curl on every bash startup
- [windows.bash] Move bash-completion source from conf.d/bash-completion.bash

## Benefits

- Reduces unnecessary network requests on bash startup
- Better behavior towards GitHub servers
- Faster bash initialization