### PR TITLE
atuin: --disable-ai --disable-up-arrowオプションを追加

### DIFF
--- a/.config/bash/conf.d/atuin.bash
+++ b/.config/bash/conf.d/atuin.bash
@@ -6,5 +6,5 @@ source ~/.bash-preexec.sh
 # https://hub.atuin.sh/
 # https://docs.atuin.sh/cli/
 if [[ $- == *i* ]] && [[ "${TERM:-}" != "dumb" ]] && command -v atuin >/dev/null 2>&1; then
-    eval "$(atuin init bash)"
+    eval "$(atuin init bash --disable-ai --disable-up-arrow)"
 fi


### PR DESCRIPTION
## 概要

`atuin init bash`に`--disable-ai`と`--disable-up-arrow`オプションを追加しました。

## 変更内容

- `.config/bash/conf.d/atuin.bash`: atuin初期化コマンドに以下のオプションを追加
  - `--disable-ai`: AI機能を無効化
  - `--disable-up-arrow`: 上矢印キーによる履歴検索を無効化

これにより、atuinのAI補完と上矢印キーでの履歴検索が無効になります。
